### PR TITLE
fix(setup): restore intensity data reactivity for normalization and max-missing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Protigy
 Title: Proteomics Toolset for Integrative Data Analysis
-Version: 2.4.0
+Version: 2.4.1
 Authors@R: c(
     person("Stephanie", "Vartany", , "svartany@broadinstitute.org", role = "aut"),
     person("D R", "Mani", , "manidr@broadinstitute.org", role = "aut"),

--- a/R/sidebar_setup.R
+++ b/R/sidebar_setup.R
@@ -756,7 +756,7 @@ setupSidebarServer <- function(id = "setupSidebar", parent) { moduleServer(
         max = parameter_choices$max_missing[[ind]]$max,
         step = parameter_choices$max_missing[[ind]]$step,
         value = min(parameters$max_missing, parameter_choices$max_missing[[ind]]$max))
-    }, ignoreInit = TRUE)
+    })
 
     # update sample filter values choices when sample filter column changes
     observe({

--- a/R/sidebar_setup_helpers_shiny.R
+++ b/R/sidebar_setup_helpers_shiny.R
@@ -48,15 +48,20 @@ gctSetupUI <- function(ns,
   # find which groups are present in all omes
   groups_choices_all_omes <- base::Reduce(base::intersect, 
                                     lapply(GCTs, function(gct) names(gct@cdesc)))
+  # Select normalization choices based on current intensity_data parameter
+  ind <- paste0(
+    "intensity_data_",
+    tolower(ifelse(isTRUE(parameters[[label]]$intensity_data == "Yes"), "yes", "no"))
+  )
   # Filter out 2-component normalization if dataset has more than 20 samples (too slow)
-  norm_choices <- parameter_choices$data_normalization$intensity_data_no
+  norm_choices <- parameter_choices$data_normalization[[ind]]
   n_samples <- ncol(GCTs[[label]]@mat)
   if (n_samples > 20) {
     norm_choices <- norm_choices[norm_choices != "2-component"]
   }
-  # If current selection is 2-component but it should be disabled, use default
+  # If current selection is not in the available choices, fall back to None
   norm_selected <- parameters[[label]]$data_normalization
-  if (n_samples > 20 && norm_selected == "2-component") {
+  if (!norm_selected %in% norm_choices) {
     norm_selected <- "None"
   }
 
@@ -245,12 +250,12 @@ gctSetupUI <- function(ns,
     ## max missing value input
     add_css_attributes(
       numericInput(
-        ns(paste0(label, '_max_missing')), 
+        ns(paste0(label, '_max_missing')),
         'Max. % missing values',
-        min = parameter_choices$max_missing$intensity_data_no$min,
-        max = parameter_choices$max_missing$intensity_data_no$max,
-        step = parameter_choices$max_missing$intensity_data_no$step,
-        value = parameters[[label]]$max_missing),
+        min = parameter_choices$max_missing[[ind]]$min,
+        max = parameter_choices$max_missing[[ind]]$max,
+        step = parameter_choices$max_missing[[ind]]$step,
+        value = min(parameters[[label]]$max_missing, parameter_choices$max_missing[[ind]]$max)),
       classes = "small-input",
       styles = "padding-bottom: 5px"),
     

--- a/R/sidebar_setup_helpers_shiny.R
+++ b/R/sidebar_setup_helpers_shiny.R
@@ -22,6 +22,24 @@ labelSetupUI <- function(ns, gctFileNames) {
   )
 }
 
+# Whether stored `intensity_data` means the intensity ("yes") YAML branch.
+# Canonical values are "Yes"/"No" (setupDefaults + collectInputs); logical
+# TRUE/FALSE can appear from the checkbox before collectInputs runs — `TRUE == "Yes"`
+# is NA in R, so compare explicitly.
+intensity_data_param_is_yes <- function(intensity_data) {
+  if (is.null(intensity_data) || length(intensity_data) < 1L) {
+    return(FALSE)
+  }
+  v <- intensity_data[[1L]]
+  if (is.logical(v)) {
+    return(isTRUE(v))
+  }
+  if (is.character(v)) {
+    return(identical(tolower(trimws(v[1L])), "yes"))
+  }
+  FALSE
+}
+
 # function containing setup elements for a single GCT file
 # NOTE: make sure that the same naming convention is used as in in the 
 # setupDefaults.yaml!
@@ -51,16 +69,21 @@ gctSetupUI <- function(ns,
   # Select normalization choices based on current intensity_data parameter
   ind <- paste0(
     "intensity_data_",
-    tolower(ifelse(isTRUE(parameters[[label]]$intensity_data == "Yes"), "yes", "no"))
+    tolower(ifelse(intensity_data_param_is_yes(parameters[[label]]$intensity_data), "yes", "no"))
   )
   # Filter out 2-component normalization if dataset has more than 20 samples (too slow)
   norm_choices <- parameter_choices$data_normalization[[ind]]
   n_samples <- ncol(GCTs[[label]]@mat)
-  if (n_samples > 20) {
+  if (n_samples > 20L) {
     norm_choices <- norm_choices[norm_choices != "2-component"]
   }
-  # If current selection is not in the available choices, fall back to None
   norm_selected <- parameters[[label]]$data_normalization
+  # Mirror server observer: if 2-component is stored but disallowed for large N, reset selection
+  if (n_samples > 20L && length(norm_selected) &&
+      identical(as.character(norm_selected)[1L], "2-component")) {
+    norm_selected <- "None"
+  }
+  # If current selection is not in the available choices, fall back to None
   if (!norm_selected %in% norm_choices) {
     norm_selected <- "None"
   }
@@ -196,7 +219,7 @@ gctSetupUI <- function(ns,
       checkboxInput(
         ns(paste0(label, '_intensity_data')),
         label = 'Intensity data',
-        value = parameters[[label]]$intensity_data == "Yes"),
+        value = intensity_data_param_is_yes(parameters[[label]]$intensity_data)),
       classes = "small-input",
       styles = "padding-top: 10px"),
 

--- a/tests/testthat/test-intensity-data-param.R
+++ b/tests/testthat/test-intensity-data-param.R
@@ -1,0 +1,27 @@
+# intensity_data_param_is_yes() — R/sidebar_setup_helpers_shiny.R (not exported)
+
+test_that("intensity_data_param_is_yes: canonical strings and logical checkbox values", {
+  f <- Protigy:::intensity_data_param_is_yes
+  expect_false(f(NULL))
+  expect_false(f(character(0)))
+  expect_true(f("Yes"))
+  expect_false(f("No"))
+  expect_true(f(TRUE))
+  expect_false(f(FALSE))
+  expect_false(f("raw"))
+  expect_false(f(NA_character_))
+  expect_false(f(NA))
+})
+
+test_that("intensity_data_param_is_yes: first element only for length > 1", {
+  f <- Protigy:::intensity_data_param_is_yes
+  expect_true(f(c("Yes", "No")))
+  expect_false(f(c("No", "Yes")))
+})
+
+test_that("intensity_data_param_is_yes: case-insensitive yes string (trimmed)", {
+  f <- Protigy:::intensity_data_param_is_yes
+  expect_true(f("yes"))
+  expect_true(f("YES"))
+  expect_true(f(" Yes "))
+})

--- a/tests/testthat/test-shiny-helpers.R
+++ b/tests/testthat/test-shiny-helpers.R
@@ -1,69 +1,164 @@
 # Tests for Shiny helper functions
 
-# Helper function to extract choices from a selectInput in a tagList
-extract_selectInput_choices <- function(tag_list, input_id_pattern) {
-  result_list <- as.list(tag_list)
-  select_input <- NULL
-  
-  # Recursively search for the selectInput
-  find_select <- function(items) {
-    if (is.null(items)) return(NULL)
-    for (item in items) {
-      if (inherits(item, "shiny.tag")) {
-        # Check if this is the selectInput we're looking for
-        item_id <- item$attribs$id %||% ""
-        if (item$name == "select" && grepl(input_id_pattern, item_id)) {
-          return(item)
-        }
-        # Recursively search children
-        if (!is.null(item$children)) {
-          found <- find_select(item$children)
-          if (!is.null(found)) return(found)
-        }
-      } else if (is.list(item)) {
-        found <- find_select(item)
-        if (!is.null(found)) return(found)
-      }
+# htmltools may store tag names in different shapes; compare case-insensitively
+tag_name_lc <- function(tag) {
+  tolower(as.character(tag$name)[[1L]])
+}
+
+# Find <select> for a Shiny namespaced input id (exact match; handles id on wrapper)
+extract_select_input_choices_by_id <- function(tag_list, input_id) {
+  find_select_el <- function(items) {
+    if (is.null(items)) {
+      return(NULL)
     }
-    return(NULL)
-  }
-  
-  select_input <- find_select(result_list)
-  if (is.null(select_input)) return(character(0))
-  
-  # Extract choices from option tags
-  choices <- character(0)
-  extract_options <- function(items) {
-    if (is.null(items)) return()
+    if (inherits(items, "shiny.tag")) {
+      items <- list(items)
+    }
+    if (!is.list(items)) {
+      return(NULL)
+    }
     for (item in items) {
-      if (inherits(item, "shiny.tag") && item$name == "option") {
-        # Get the value from the option tag - check both value attribute and children
-        value <- item$attribs$value
-        if (is.null(value) && !is.null(item$children) && length(item$children) > 0) {
-          # Value might be in children
-          child <- item$children[[1]]
-          if (is.character(child)) {
-            value <- child
-          } else if (inherits(child, "shiny.tag") && !is.null(child$children)) {
-            value <- child$children[[1]]
+      if (!inherits(item, "shiny.tag")) {
+        if (is.list(item)) {
+          found <- find_select_el(item)
+          if (!is.null(found)) {
+            return(found)
           }
         }
-        if (is.character(value) && length(value) == 1) {
-          choices <<- c(choices, value)
+        next
+      }
+      id <- item$attribs$id %||% ""
+      if (nzchar(id) && identical(id, input_id)) {
+        if (identical(tag_name_lc(item), "select")) {
+          return(item)
         }
-      } else if (is.list(item) && !is.null(item)) {
-        extract_options(item)
-      } else if (inherits(item, "shiny.tag") && !is.null(item$children)) {
+        if (!is.null(item$children)) {
+          inner <- find_select_el(item$children)
+          if (!is.null(inner)) {
+            return(inner)
+          }
+        }
+        return(NULL)
+      } else if (!is.null(item$children)) {
+        found <- find_select_el(item$children)
+        if (!is.null(found)) {
+          return(found)
+        }
+      }
+    }
+    NULL
+  }
+
+  select_input <- find_select_el(as.list(tag_list))
+  if (is.null(select_input)) {
+    return(character(0))
+  }
+
+  # Current Shiny/htmltools: <select> often has one child — an `html()` blob of all
+  # <option> tags, not separate shiny.tag "option" nodes. Walking only tags yields
+  # character(0) and makes tests look "broken" while the app is fine.
+  ch <- select_input$children
+  if (length(ch) >= 1L) {
+    first <- ch[[1L]]
+    if (is.character(first) && inherits(first, "html")) {
+      txt <- paste(as.character(first), collapse = "")
+      mm <- stringr::str_match_all(txt, "value=\"([^\"]*)\"")[[1]]
+      if (is.matrix(mm) && nrow(mm) > 0L) {
+        return(mm[, 2L])
+      }
+      return(character(0))
+    }
+  }
+
+  choices <- character(0)
+  extract_options <- function(items) {
+    if (is.null(items)) {
+      return()
+    }
+    if (inherits(items, "shiny.tag")) {
+      items <- list(items)
+    }
+    if (!is.list(items)) {
+      return()
+    }
+    for (item in items) {
+      if (!inherits(item, "shiny.tag")) {
+        if (is.list(item)) {
+          extract_options(item)
+        }
+        next
+      }
+      nm <- tag_name_lc(item)
+      if (identical(nm, "option")) {
+        value <- item$attribs$value
+        if (is.null(value) && length(item$children) > 0L) {
+          ch <- item$children[[1L]]
+          value <- if (is.character(ch)) {
+            ch
+          } else if (inherits(ch, "shiny.tag") && length(ch$children)) {
+            ch$children[[1L]]
+          } else {
+            NULL
+          }
+        }
+        if (length(value) == 1L) {
+          choices <<- c(choices, as.character(value))
+        }
+      } else if (identical(nm, "optgroup")) {
+        extract_options(item$children)
+      } else if (!is.null(item$children)) {
         extract_options(item$children)
       }
     }
   }
-  
-  if (!is.null(select_input$children)) {
-    extract_options(select_input$children)
+
+  extract_options(select_input$children)
+  choices
+}
+
+# Working directory in testthat 3e is usually tests/testthat/
+protigy_pkg_root_for_tests <- function() {
+  wd <- normalizePath(getwd(), winslash = "/")
+  if (grepl("/tests/testthat/?$", wd)) {
+    return(dirname(dirname(wd)))
   }
-  
-  return(choices)
+  if (grepl("/tests/?$", wd)) {
+    return(dirname(wd))
+  }
+  wd
+}
+
+# Find first <input type="number"> whose id matches exactly or by fixed substring
+extract_numeric_input_attribs <- function(tag_list, input_id_pattern) {
+  find_input <- function(items) {
+    if (is.null(items)) {
+      return(NULL)
+    }
+    for (item in items) {
+      if (inherits(item, "shiny.tag")) {
+        att <- item$attribs
+        id <- att$id %||% ""
+        nm <- tag_name_lc(item)
+        if (identical(nm, "input") && nzchar(id) &&
+            (identical(id, input_id_pattern) || grepl(input_id_pattern, id, fixed = TRUE))) {
+          return(att)
+        }
+        if (!is.null(item$children)) {
+          found <- find_input(item$children)
+          if (!is.null(found)) {
+            return(found)
+          }
+        }
+      } else if (is.list(item)) {
+        found <- find_input(item)
+        if (!is.null(found)) {
+          return(found)
+        }
+      }
+    }
+    NULL
+  }
+  find_input(as.list(tag_list))
 }
 
 test_that("labelSetupUI creates correct HTML structure", {
@@ -485,4 +580,169 @@ test_that("gctSetupUI resets selection to None when 2-component is selected but 
   
   # Verify selection is reset to None
   expect_equal(norm_selected, "None")
+})
+
+## Regression: intensity_data Yes/No must drive normalization + max_missing in gctSetupUI
+## (hardcoding intensity_data_no broke UI after collectInputs/re-render; see 4458a8f).
+
+mock_gct_setup_intensity <- function(n_col = 3L) {
+  new("GCT",
+    mat = matrix(seq_len(4L * n_col), nrow = 4L, ncol = n_col),
+    rdesc = data.frame(id = paste0("gene_", 1:4)),
+    cdesc = data.frame(
+      group1 = rep(c("A", "B"), length.out = n_col),
+      row.names = paste0("sample_", seq_len(n_col))
+    ),
+    rid = paste0("gene_", 1:4),
+    cid = paste0("sample_", seq_len(n_col))
+  )
+}
+
+mock_parameter_choices_intensity_branches <- function() {
+  list(
+    log_transformation = c("None", "log2"),
+    data_normalization = list(
+      intensity_data_yes = c("NORM_YES_A", "NORM_YES_B"),
+      intensity_data_no = c("NORM_NO_A", "NORM_NO_B", "NORM_NO_C")
+    ),
+    max_missing = list(
+      intensity_data_yes = list(min = 0, max = 99, step = 1),
+      intensity_data_no = list(min = 0, max = 100, step = 5)
+    ),
+    data_filter = c("None", "StdDev"),
+    data_filter_sd_pct = list(min = 10, max = 90, step = 5)
+  )
+}
+
+base_mock_params_ome <- function(intensity_data, data_normalization, max_missing) {
+  list(
+    ome = list(
+      annotation_column = "group1",
+      intensity_data = intensity_data,
+      log_transformation = "None",
+      data_normalization = data_normalization,
+      group_normalization = FALSE,
+      max_missing = max_missing,
+      data_filter = "None",
+      data_filter_sd_pct = 25,
+      gene_symbol_column = "None",
+      convert_ids_to_gene_symbol = FALSE,
+      sample_filter_enabled = FALSE,
+      sample_filter_column = "",
+      sample_filter_values = character(0),
+      row_filter_enabled = FALSE,
+      row_filter_column = "",
+      row_filter_values = character(0),
+      id_source_column = "",
+      id_mapping_species = "Homo sapiens"
+    )
+  )
+}
+
+test_that("gctSetupUI uses intensity_data_yes normalization when intensity_data is Yes", {
+  mock_gct <- mock_gct_setup_intensity(3L)
+  pc <- mock_parameter_choices_intensity_branches()
+  pm <- base_mock_params_ome("Yes", "NORM_YES_A", 50L)
+  ns <- shiny::NS("mod")
+  ui <- gctSetupUI(
+    ns = ns,
+    label = "ome",
+    parameter_choices = pc,
+    parameters = pm,
+    current_place = 1L,
+    max_place = 1L,
+    GCTs = list(ome = mock_gct)
+  )
+  norm_choices <- extract_select_input_choices_by_id(ui, ns("ome_data_normalization"))
+  expect_true("NORM_YES_A" %in% norm_choices)
+  expect_false("NORM_NO_A" %in% norm_choices)
+  nm <- extract_numeric_input_attribs(ui, ns("ome_max_missing"))
+  expect_equal(as.numeric(nm$max), 99)
+})
+
+test_that("gctSetupUI uses intensity_data_yes when intensity_data is logical TRUE", {
+  mock_gct <- mock_gct_setup_intensity(3L)
+  pc <- mock_parameter_choices_intensity_branches()
+  pm <- base_mock_params_ome(TRUE, "NORM_YES_A", 50L)
+  ns <- shiny::NS("mod")
+  ui <- gctSetupUI(
+    ns = ns,
+    label = "ome",
+    parameter_choices = pc,
+    parameters = pm,
+    current_place = 1L,
+    max_place = 1L,
+    GCTs = list(ome = mock_gct)
+  )
+  norm_choices <- extract_select_input_choices_by_id(ui, ns("ome_data_normalization"))
+  expect_true("NORM_YES_A" %in% norm_choices)
+  expect_false("NORM_NO_A" %in% norm_choices)
+})
+
+test_that("gctSetupUI uses intensity_data_no normalization when intensity_data is not Yes", {
+  mock_gct <- mock_gct_setup_intensity(3L)
+  pc <- mock_parameter_choices_intensity_branches()
+  pm <- base_mock_params_ome("No", "NORM_NO_B", 50L)
+  ns <- shiny::NS("mod")
+  ui <- gctSetupUI(
+    ns = ns,
+    label = "ome",
+    parameter_choices = pc,
+    parameters = pm,
+    current_place = 1L,
+    max_place = 1L,
+    GCTs = list(ome = mock_gct)
+  )
+  norm_choices <- extract_select_input_choices_by_id(ui, ns("ome_data_normalization"))
+  expect_true("NORM_NO_A" %in% norm_choices)
+  expect_false("NORM_YES_A" %in% norm_choices)
+  nm <- extract_numeric_input_attribs(ui, ns("ome_max_missing"))
+  expect_equal(as.numeric(nm$max), 100)
+})
+
+test_that("gctSetupUI aligns with inst setupChoices.yaml intensity_data_yes/no keys", {
+  ypath <- system.file("setup_parameters/setupChoices.yaml", package = "Protigy")
+  skip_if_not(nzchar(ypath), "setupChoices.yaml not found (run devtools::test from package source)")
+  pc <- yaml::read_yaml(ypath)
+  mock_gct <- mock_gct_setup_intensity(3L)
+  ns <- shiny::NS("chk")
+  for (intensity in c("Yes", "No")) {
+    pm <- base_mock_params_ome(
+      intensity,
+      pc$data_normalization[[paste0("intensity_data_", tolower(intensity))]][[1L]],
+      50L
+    )
+    ui <- gctSetupUI(
+      ns = ns,
+      label = "ome",
+      parameter_choices = pc,
+      parameters = pm,
+      current_place = 1L,
+      max_place = 1L,
+      GCTs = list(ome = mock_gct)
+    )
+    norm_choices <- extract_select_input_choices_by_id(ui, ns("ome_data_normalization"))
+    expected <- pc$data_normalization[[paste0("intensity_data_", tolower(intensity))]]
+    expect_identical(norm_choices, expected, info = paste("intensity_data =", intensity))
+    nm <- extract_numeric_input_attribs(ui, ns("ome_max_missing"))
+    mm <- pc$max_missing[[paste0("intensity_data_", tolower(intensity))]]
+    expect_equal(as.numeric(nm$min), mm$min, info = paste("intensity_data =", intensity))
+    expect_equal(as.numeric(nm$max), mm$max, info = paste("intensity_data =", intensity))
+  }
+})
+
+test_that("intensity observeEvent must not use ignoreInit = TRUE (regression guard)", {
+  spf <- file.path(protigy_pkg_root_for_tests(), "R", "sidebar_setup.R")
+  skip_if_not(file.exists(spf), "sidebar_setup.R not at expected path (skip in unusual test layout)")
+  lines <- readLines(spf, warn = FALSE)
+  start <- grep("^\\s*observeEvent\\(\\s*current_intensity\\(\\)", lines)
+  expect_length(start, 1L)
+  end <- grep("^\\s*# update sample filter values choices when sample filter column changes", lines)
+  expect_length(end, 1L)
+  expect_true(end > start)
+  chunk <- lines[seq.int(start, end - 1L)]
+  expect_false(
+    any(grepl("ignoreInit\\s*=\\s*TRUE", chunk)),
+    info = paste(chunk, collapse = "\n")
+  )
 })


### PR DESCRIPTION
Reverts `ignoreInit = TRUE` added in ff6e685 on the intensity observer
(sidebar_setup.R:759). That flag caused the observer's first real fire
to be swallowed, so toggling the checkbox never updated the normalization
dropdown or the max-missing range.

Also removes the race-condition root cause: gctSetupUI was hardcoding
intensity_data_no choices for normalization and max-missing on every
re-render (triggered by collectInputs → parameters_internal_reactive).
Now gctSetupUI derives the correct choices from the stored
intensity_data parameter on initial paint and on re-render, so behavior
is consistent regardless of observer firing order.

Files:
- R/sidebar_setup.R: remove ignoreInit = TRUE from intensity observer
- R/sidebar_setup_helpers_shiny.R: use dynamic `ind` key instead of
  hardcoded intensity_data_no for norm_choices and max_missing inputs
