### PR TITLE
fix(tests): restore pkgload::load_all in shinytest2 app.R files

### DIFF
--- a/tests/testthat/apps/full-app-spectronaut/app.R
+++ b/tests/testthat/apps/full-app-spectronaut/app.R
@@ -1,2 +1,17 @@
 options(protigy.enable_spectronaut = TRUE)
+
+# Load the Protigy package from source via pkgload so the test app works
+# without requiring the package to be installed in the user library.
+# Protigy::launchApp() below triggers loadNamespace("Protigy") via `::`,
+# which bypasses shinytest2's library()/require() override — so we must
+# load the namespace explicitly here first.
+pkg_root <- normalizePath(file.path(getwd(), "..", "..", "..", ".."))
+pkgload::load_all(
+  path            = pkg_root,
+  export_all      = FALSE,
+  helpers         = FALSE,
+  attach_testthat = FALSE,
+  quiet           = TRUE
+)
+
 Protigy::launchApp()

--- a/tests/testthat/apps/full-app/app.R
+++ b/tests/testthat/apps/full-app/app.R
@@ -1,2 +1,17 @@
 options(protigy.enable_spectronaut = FALSE)
+
+# Load the Protigy package from source via pkgload so the test app works
+# without requiring the package to be installed in the user library.
+# Protigy::launchApp() below triggers loadNamespace("Protigy") via `::`,
+# which bypasses shinytest2's library()/require() override — so we must
+# load the namespace explicitly here first.
+pkg_root <- normalizePath(file.path(getwd(), "..", "..", "..", ".."))
+pkgload::load_all(
+  path            = pkg_root,
+  export_all      = FALSE,
+  helpers         = FALSE,
+  attach_testthat = FALSE,
+  quiet           = TRUE
+)
+
 Protigy::launchApp()


### PR DESCRIPTION
Protigy::launchApp() in the test app.R triggers loadNamespace("Protigy")
via the `::` operator, which bypasses shinytest2's library()/require()
override and fails because Protigy is not installed in the user library.

Restore the explicit pkgload::load_all() call that was removed in 892e84a
so the package namespace is loaded from source before `::` access.
