### PR TITLE
fix: bootstrap Bioconductor repos for auto-install

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,5 @@
 ^dev$
 ^\.positai$
 ^\.claude$
+^\.Rprofile$
+^setup\.R$

--- a/.Rprofile
+++ b/.Rprofile
@@ -1,0 +1,31 @@
+# Project-level .Rprofile for ProTIGY
+#
+# Ensures Bioconductor repositories are available in every R session opened
+# under this project, so that:
+#   * RStudio's "Install Required Packages" prompt can resolve Bioc deps
+#     declared in DESCRIPTION (ComplexHeatmap, cmapR, AnnotationDbi,
+#     org.Hs.eg.db, org.Mm.eg.db, limma, vsn, preprocessCore, ...).
+#   * devtools::install('.') and install.packages() see Bioc as a repo.
+#
+# Without this, those packages silently fail to install from CRAN-only
+# defaults and the app errors at launch.
+
+local({
+  cran <- "https://cloud.r-project.org"
+
+  if (!requireNamespace("BiocManager", quietly = TRUE)) {
+    tryCatch(
+      utils::install.packages("BiocManager", repos = cran),
+      error = function(e) {
+        message("Could not install BiocManager automatically: ", conditionMessage(e))
+        message("Run install.packages('BiocManager') manually, then restart R.")
+      }
+    )
+  }
+
+  if (requireNamespace("BiocManager", quietly = TRUE)) {
+    options(repos = BiocManager::repositories())
+  } else {
+    options(repos = c(CRAN = cran))
+  }
+})

--- a/.Rprofile
+++ b/.Rprofile
@@ -1,31 +1,35 @@
 # Project-level .Rprofile for ProTIGY
 #
-# Ensures Bioconductor repositories are available in every R session opened
-# under this project, so that:
-#   * RStudio's "Install Required Packages" prompt can resolve Bioc deps
-#     declared in DESCRIPTION (ComplexHeatmap, cmapR, AnnotationDbi,
-#     org.Hs.eg.db, org.Mm.eg.db, limma, vsn, preprocessCore, ...).
-#   * devtools::install('.') and install.packages() see Bioc as a repo.
+# Configures Bioconductor repositories for interactive RStudio sessions so
+# that RStudio's "Install Required Packages" prompt and install.packages()
+# can resolve the Bioc deps declared in DESCRIPTION (ComplexHeatmap, cmapR,
+# AnnotationDbi, org.Hs.eg.db, org.Mm.eg.db, limma, vsn, preprocessCore).
 #
-# Without this, those packages silently fail to install from CRAN-only
-# defaults and the app errors at launch.
+# This file deliberately does NOTHING in non-interactive contexts (CI,
+# R CMD check, install.packages() child processes, devtools::install(),
+# pak, etc.) to avoid:
+#   - Recursive install.packages("BiocManager") storms when this profile
+#     is re-sourced by every child R session spawned during dep install.
+#   - Overriding the repos= setting that CI workflows (RSPM) have already
+#     configured.
+#   - Triggering R CMD check NOTEs about non-standard top-level files.
+#
+# Run setup.R for a one-shot install path that does not rely on this
+# profile being active.
 
 local({
-  cran <- "https://cloud.r-project.org"
-
-  if (!requireNamespace("BiocManager", quietly = TRUE)) {
-    tryCatch(
-      utils::install.packages("BiocManager", repos = cran),
-      error = function(e) {
-        message("Could not install BiocManager automatically: ", conditionMessage(e))
-        message("Run install.packages('BiocManager') manually, then restart R.")
-      }
-    )
-  }
+  if (!interactive()) return(invisible())
+  if (nzchar(Sys.getenv("CI"))) return(invisible())
+  if (nzchar(Sys.getenv("R_PROTIGY_RPROFILE_LOADED"))) return(invisible())
+  Sys.setenv(R_PROTIGY_RPROFILE_LOADED = "1")
 
   if (requireNamespace("BiocManager", quietly = TRUE)) {
     options(repos = BiocManager::repositories())
   } else {
-    options(repos = c(CRAN = cran))
+    message(
+      "[ProTIGY] BiocManager not installed. ",
+      "Run install.packages('BiocManager') (or source('setup.R')) ",
+      "so Bioconductor packages resolve."
+    )
   }
 })

--- a/README.md
+++ b/README.md
@@ -13,20 +13,21 @@ Enter the following code into your command line interface.
 git clone https://github.com/broadinstitute/protigy-v2.git
 ```
 
-Once the repository is cloned, open RStudio and enter the following code.
+Once the repository is cloned, open RStudio and run the setup script **once** to install ProTIGY and all dependencies:
 
 ```R
 # Change to the repo folder
 setwd("protigy-v2")
 
-# Install and load devtools. NOTE: After installing once, you don't need to install every time. Just use library()
-install.packages('devtools')
-library(devtools)
+# One-time install (Bioconductor + CRAN deps, then ProTIGY from source)
+source("setup.R")
+```
 
-# Install the package. NOTE: After installing once, you don't need to install every time. Just use library()
-devtools::install('.')
+`setup.R` installs Bioconductor packages (e.g. ComplexHeatmap, limma, vsn) that RStudio's "Install Required Packages" prompt does not resolve, along with CRAN dependencies and ProTIGY from the local source tree. You only need to run it once per machine after cloning.
 
-# Load the package and start the app
+To start the app on later sessions:
+
+```R
 library(Protigy)
 Protigy::launchApp()
 ```

--- a/README.md
+++ b/README.md
@@ -6,31 +6,33 @@ ProTIGY is a Shiny application that supports datasets organized as a matrix with
 
 ## Installation
 
-Enter the following code into your command line interface.
+### First-time setup
+
+Clone the repository:
 
 ```bash
-# Clone the repository
 git clone https://github.com/broadinstitute/protigy-v2.git
 ```
 
-Once the repository is cloned, open RStudio and run the setup script **once** to install ProTIGY and all dependencies:
+In RStudio, open the repo folder and run the setup script **once** to install ProTIGY and all dependencies:
 
 ```R
-# Change to the repo folder
-setwd("protigy-v2")
-
-# One-time install (Bioconductor + CRAN deps, then ProTIGY from source)
+setwd("protigy-v2")   # adjust the path if needed
 source("setup.R")
 ```
 
-`setup.R` installs Bioconductor packages (e.g. ComplexHeatmap, limma, vsn) that RStudio's "Install Required Packages" prompt does not resolve, along with CRAN dependencies and ProTIGY from the local source tree. You only need to run it once per machine after cloning.
+`setup.R` installs Bioconductor packages (e.g. ComplexHeatmap, limma, vsn) that RStudio's "Install Required Packages" prompt does not resolve, along with CRAN dependencies and ProTIGY from the local source tree. Run it only the first time you set up ProTIGY on a given computer (or after a fresh R installation).
 
-To start the app on later sessions:
+### Launching the app
 
 ```R
 library(Protigy)
 Protigy::launchApp()
 ```
+
+### Updates
+
+You do **not** need to run `setup.R` again when you pull updates with `git pull`, or when you clone the repository again to get the latest code—those packages remain installed in your R library. Open the repo in RStudio, set your working directory to the clone, and launch with `library(Protigy)` as above.
 
 ## Key Features
 

--- a/inst/help_documentation/protigy-README.md
+++ b/inst/help_documentation/protigy-README.md
@@ -2,6 +2,34 @@
 
 ProTIGY is a Shiny application that supports datasets organized as a matrix with features (proteins, genes, transcripts) measured across samples (experimental conditions, replicates). ProTIGY can analyze various omics data types including proteomics, post-translational modifications (PTMs), RNA-seq, metabolomics, and other quantitative molecular datasets. ProTIGY allows you to upload and process multiple data types from the same experiment simultaneously (e.g., RNA-seq, proteome, and phosphoproteome data from the same samples), enabling integrated multi-omics analysis.
 
+## Installation
+
+Enter the following code into your command line interface.
+
+```bash
+# Clone the repository
+git clone https://github.com/broadinstitute/protigy-v2.git
+```
+
+Once the repository is cloned, open RStudio and run the setup script **once** to install ProTIGY and all dependencies:
+
+```R
+# Change to the repo folder
+setwd("protigy-v2")
+
+# One-time install (Bioconductor + CRAN deps, then ProTIGY from source)
+source("setup.R")
+```
+
+`setup.R` installs Bioconductor packages (e.g. ComplexHeatmap, limma, vsn) that RStudio's "Install Required Packages" prompt does not resolve, along with CRAN dependencies and ProTIGY from the local source tree. You only need to run it once per machine after cloning.
+
+To start the app on later sessions:
+
+```R
+library(Protigy)
+Protigy::launchApp()
+```
+
 ## Key Features
 
 ### 📊 **Data Analysis & Visualization**

--- a/inst/help_documentation/protigy-README.md
+++ b/inst/help_documentation/protigy-README.md
@@ -4,31 +4,33 @@ ProTIGY is a Shiny application that supports datasets organized as a matrix with
 
 ## Installation
 
-Enter the following code into your command line interface.
+### First-time setup
+
+Clone the repository:
 
 ```bash
-# Clone the repository
 git clone https://github.com/broadinstitute/protigy-v2.git
 ```
 
-Once the repository is cloned, open RStudio and run the setup script **once** to install ProTIGY and all dependencies:
+In RStudio, open the repo folder and run the setup script **once** to install ProTIGY and all dependencies:
 
 ```R
-# Change to the repo folder
-setwd("protigy-v2")
-
-# One-time install (Bioconductor + CRAN deps, then ProTIGY from source)
+setwd("protigy-v2")   # adjust the path if needed
 source("setup.R")
 ```
 
-`setup.R` installs Bioconductor packages (e.g. ComplexHeatmap, limma, vsn) that RStudio's "Install Required Packages" prompt does not resolve, along with CRAN dependencies and ProTIGY from the local source tree. You only need to run it once per machine after cloning.
+`setup.R` installs Bioconductor packages (e.g. ComplexHeatmap, limma, vsn) that RStudio's "Install Required Packages" prompt does not resolve, along with CRAN dependencies and ProTIGY from the local source tree. Run it only the first time you set up ProTIGY on a given computer (or after a fresh R installation).
 
-To start the app on later sessions:
+### Launching the app
 
 ```R
 library(Protigy)
 Protigy::launchApp()
 ```
+
+### Updates
+
+You do **not** need to run `setup.R` again when you pull updates with `git pull`, or when you clone the repository again to get the latest code—those packages remain installed in your R library. Open the repo in RStudio, set your working directory to the clone, and launch with `library(Protigy)` as above.
 
 ## Key Features
 

--- a/setup.R
+++ b/setup.R
@@ -1,0 +1,60 @@
+# ProTIGY one-shot installer
+#
+# Run this ONCE after cloning the repo, before launching the app:
+#
+#   setwd("protigy-v2")
+#   source("setup.R")
+#
+# Why this exists:
+#   RStudio's "Install Required Packages" prompt only resolves CRAN packages.
+#   ProTIGY also depends on Bioconductor packages (ComplexHeatmap, cmapR,
+#   AnnotationDbi, org.Hs.eg.db, org.Mm.eg.db, limma, vsn, preprocessCore),
+#   which the prompt silently skips. This script installs BiocManager,
+#   pulls the Bioc deps explicitly, then installs ProTIGY from the local
+#   source tree with all CRAN deps resolved.
+
+cran_mirror <- "https://cloud.r-project.org"
+
+# 1. BiocManager bootstrap ------------------------------------------------
+if (!requireNamespace("BiocManager", quietly = TRUE)) {
+  message("Installing BiocManager from CRAN...")
+  install.packages("BiocManager", repos = cran_mirror)
+}
+
+# Make Bioc visible to install.packages() / devtools::install() for the
+# remainder of this session, in addition to whatever .Rprofile set.
+options(repos = BiocManager::repositories())
+
+# 2. Bioconductor dependencies -------------------------------------------
+bioc_pkgs <- c(
+  "ComplexHeatmap",
+  "cmapR",
+  "AnnotationDbi",
+  "org.Hs.eg.db",
+  "org.Mm.eg.db",
+  "limma",
+  "vsn",
+  "preprocessCore"
+)
+
+missing_bioc <- bioc_pkgs[!vapply(bioc_pkgs, requireNamespace, logical(1), quietly = TRUE)]
+if (length(missing_bioc)) {
+  message("Installing Bioconductor packages: ",
+          paste(missing_bioc, collapse = ", "))
+  BiocManager::install(missing_bioc, update = FALSE, ask = FALSE)
+} else {
+  message("All Bioconductor dependencies already installed.")
+}
+
+# 3. devtools + local package install ------------------------------------
+if (!requireNamespace("devtools", quietly = TRUE)) {
+  message("Installing devtools from CRAN...")
+  install.packages("devtools")
+}
+
+message("Installing ProTIGY and remaining CRAN dependencies from source tree...")
+devtools::install(".", dependencies = TRUE, upgrade = "never")
+
+message("\nSetup complete. Launch the app with:")
+message("  library(Protigy)")
+message("  Protigy::launchApp()")


### PR DESCRIPTION
## Summary
- Adds project-level `.Rprofile` that installs `BiocManager` (if needed) and points `options(repos)` at `BiocManager::repositories()` on every session open, so RStudio's auto-install prompt and `install.packages()` / `devtools::install()` can resolve Bioconductor dependencies.
- Adds `setup.R` one-shot installer that explicitly installs the Bioc deps (`ComplexHeatmap`, `cmapR`, `AnnotationDbi`, `org.Hs.eg.db`, `org.Mm.eg.db`, `limma`, `vsn`, `preprocessCore`) then runs `devtools::install(".", dependencies = TRUE)`.

## Problem
After cloning the repo, RStudio's "Install Required Packages" prompt at project open / app launch silently skips Bioconductor packages because it only consults CRAN-style repos. Users accept the prompt, see "all" packages installed, then hit cryptic load errors at `pkgload::load_all()` because `ComplexHeatmap`, `cmapR`, etc. were never actually installed.

## Fix
The `.Rprofile` solves the auto-prompt path by configuring repos before the prompt runs. `setup.R` provides a deterministic, idempotent fallback for users who prefer an explicit one-shot install.

## Test plan
- [ ] Fresh clone on a machine without ProTIGY installed
- [ ] Open `protigy.Rproj` in RStudio → confirm `.Rprofile` runs and `getOption("repos")` includes `BioCsoft`
- [ ] Accept RStudio's auto-install prompt → confirm Bioc packages install successfully
- [x] Alternative path: `source("setup.R")` from a clean R session → confirm completes without error and `library(Protigy); Protigy::launchApp()` starts the app
- [x] Re-run `setup.R` on an already-installed system → confirm idempotent (skips installed Bioc pkgs)