### PR TITLE
fix: wrap long filenames without spaces in setup sidebar

### DIFF
--- a/R/sidebar_setup.R
+++ b/R/sidebar_setup.R
@@ -277,7 +277,7 @@ setupSidebarServer <- function(id = "setupSidebar", parent) { moduleServer(
             div(
               style = "padding: 8px; margin: 3px 0; background-color: #f8f9fa; border-radius: 3px; display: flex; align-items: flex-start; justify-content: space-between; width: 100%; box-sizing: border-box; min-height: 35px; height: auto;",
               div(
-                style = "flex: 1; padding-right: 10px; color: #333; font-size: 13px; word-wrap: break-word; overflow-wrap: break-word; line-height: 1.4;",
+                style = "flex: 1 1 auto; min-width: 0; padding-right: 10px; color: #333; font-size: 13px; word-wrap: break-word; overflow-wrap: anywhere; word-break: break-word; white-space: normal; line-height: 1.4;",
                 files$name[i]
               ),
               actionButton(

--- a/inst/custom.css
+++ b/inst/custom.css
@@ -87,6 +87,11 @@ section.sidebar {
 /* the labels for all inputs*/
 .small-input .control-label {
   font-weight: 400;
+  display: block;
+  max-width: 100%;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 /* style for primary action button */


### PR DESCRIPTION
## Summary
- Long filenames without whitespace (e.g. `mb-proteome-ratio-norm-NArm.gct`) overflowed the setup sidebar because the existing CSS only used `overflow-wrap: break-word`, which only breaks at whitespace.
- Uploaded files list ([R/sidebar_setup.R:280](R/sidebar_setup.R)): switch the filename cell to `overflow-wrap: anywhere` + `word-break: break-word`, and add `min-width: 0` so the flex child can shrink below its intrinsic content width.
- Small-input control labels ([inst/custom.css](inst/custom.css)): wrap long text-input labels — used for the per-file `Label_<filename>` inputs in the label-assignment view (`labelSetupUI` in `R/sidebar_setup_helpers_shiny.R`) — so they break inside long filenames too.

## Test plan
- [x] Upload a file whose name has no spaces and is longer than the sidebar width (e.g. `mb-proteome-ratio-norm-NArm.gct`)
- [x] Confirm the entry in "Uploaded Files (N)" wraps cleanly inside the gray pill, without overflowing horizontally or hiding the remove (×) button
- [x] Continue to the "Assign labels" view; confirm the filename label above each `textInput` wraps cleanly within the sidebar
- [x] Sanity-check that short filenames render unchanged