### PR TITLE
fix(volcano): show selected label column value in hover tooltip

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Protigy
 Title: Proteomics Toolset for Integrative Data Analysis
-Version: 2.4.1
+Version: 2.5.0
 Authors@R: c(
     person("Stephanie", "Vartany", , "svartany@broadinstitute.org", role = "aut"),
     person("D R", "Mani", , "manidr@broadinstitute.org", role = "aut"),

--- a/R/tab_stat_plot_helpers.R
+++ b/R/tab_stat_plot_helpers.R
@@ -8,21 +8,38 @@
 # contrasts with darkred significant scatter points (plotVolcano sig.col).
 .volcano_label_hex <- "#FF00FF"
 
-# Build plotly hover `text` for volcano points: always `ID: …`; optional second line
-# from the real gene-symbol metadata column when `gs_vals` is provided (same length as ids).
+# Build plotly hover `text` for volcano points: always `ID: …`; optional second
+# line from the real gene-symbol metadata column when `gs_vals` is provided
+# (same length as ids); optional third line from the user-selected label column
+# when `lbl_vals` + `lbl_col_name` are provided and length matches ids.
 # @noRd
-volcano_build_hover_text <- function(ids, gs_vals = NULL, gs_col_name = NULL) {
+volcano_build_hover_text <- function(ids,
+                                     gs_vals = NULL, gs_col_name = NULL,
+                                     lbl_vals = NULL, lbl_col_name = NULL) {
   ids <- as.character(ids)
   ht  <- paste0("ID: ", ids)
-  if (is.null(gs_vals)) return(ht)
-  gs_vals <- as.character(gs_vals)
-  if (length(gs_vals) != length(ids)) return(ht)
-  nm <- if (!is.null(gs_col_name) && nzchar(as.character(gs_col_name)[1L])) {
-    as.character(gs_col_name)[1L]
-  } else {
-    "geneSymbol"
+
+  if (!is.null(gs_vals)) {
+    gs_vals <- as.character(gs_vals)
+    if (length(gs_vals) == length(ids)) {
+      nm <- if (!is.null(gs_col_name) && nzchar(as.character(gs_col_name)[1L])) {
+        as.character(gs_col_name)[1L]
+      } else {
+        "geneSymbol"
+      }
+      ht <- paste0(ht, "<br>", nm, ": ", gs_vals)
+    }
   }
-  paste0(ht, "<br>", nm, ": ", gs_vals)
+
+  if (!is.null(lbl_vals) && !is.null(lbl_col_name) &&
+      nzchar(as.character(lbl_col_name)[1L])) {
+    lbl_vals <- as.character(lbl_vals)
+    if (length(lbl_vals) == length(ids)) {
+      ht <- paste0(ht, "<br>", as.character(lbl_col_name)[1L], ": ", lbl_vals)
+    }
+  }
+
+  ht
 }
 
 # #Input parameters- 
@@ -174,12 +191,23 @@ plotVolcano <- function(ome, volcano_groups, volcano_contrasts, df, stat_params,
     group_contrast<- volcano_groups
   }
   ## Plot
-  # Hover: always ID + actual gene symbol column when present, regardless of
-  # label-column choice (trim toggle does not affect hover).
+  # Hover: always ID + the real gene-symbol column when present. When the
+  # user-selected label column is neither the id column nor the detected
+  # geneSymbol column, append a third line with the resolved label value so
+  # the tooltip matches the on-plot annotation.
+  is_id_col <- identical(tolower(lbl_col), tolower(id_col))
+  is_gs_col <- !is.null(geneSymbol_col) && !is.na(geneSymbol_col) &&
+               identical(tolower(lbl_col), tolower(geneSymbol_col))
+
+  extra_lbl_vals <- if (!is_id_col && !is_gs_col) df$geneSymbol else NULL
+  extra_lbl_name <- if (!is_id_col && !is_gs_col) lbl_col       else NULL
+
   df$.hover_text <- volcano_build_hover_text(
     df$id,
     gs_vals      = gs_for_hover,
-    gs_col_name  = geneSymbol_col
+    gs_col_name  = geneSymbol_col,
+    lbl_vals     = extra_lbl_vals,
+    lbl_col_name = extra_lbl_name
   )
   volcano <- ggplot(df, aes(x = .data$logFC, y = .data$logP,
                        text = .data$.hover_text)) +

--- a/tests/testthat/test-volcano-labeling.R
+++ b/tests/testthat/test-volcano-labeling.R
@@ -156,6 +156,40 @@ test_that("volcano_build_hover_text preserves NA in gene symbol display", {
   expect_equal(out[2], "ID: i2<br>geneSymbol: NA")
 })
 
+test_that("volcano_build_hover_text appends user-selected label column line", {
+  out <- volcano_build_hover_text(
+    c("id1", "id2"),
+    gs_vals      = c("G1", "G2"),
+    gs_col_name  = "geneSymbol",
+    lbl_vals     = c("desc1", "desc2"),
+    lbl_col_name = "description"
+  )
+  expect_equal(out, c(
+    "ID: id1<br>geneSymbol: G1<br>description: desc1",
+    "ID: id2<br>geneSymbol: G2<br>description: desc2"
+  ))
+})
+
+test_that("volcano_build_hover_text ignores lbl_vals when length mismatches ids", {
+  out <- volcano_build_hover_text(
+    c("a", "b"),
+    gs_vals      = c("G1", "G2"),
+    gs_col_name  = "geneSymbol",
+    lbl_vals     = "only_one",
+    lbl_col_name = "description"
+  )
+  expect_equal(out, c("ID: a<br>geneSymbol: G1", "ID: b<br>geneSymbol: G2"))
+})
+
+test_that("volcano_build_hover_text supports label line without gene symbol line", {
+  out <- volcano_build_hover_text(
+    c("id1", "id2"),
+    lbl_vals     = c("d1", "d2"),
+    lbl_col_name = "description"
+  )
+  expect_equal(out, c("ID: id1<br>description: d1", "ID: id2<br>description: d2"))
+})
+
 ## volcano_label_top_significant_subset ########################################
 
 test_that("volcano_label_top_significant_subset returns top n by logP among significant", {


### PR DESCRIPTION
Closes #89

## Summary
- When a user picks a label column on the volcano plot that is neither the `id` nor the detected `geneSymbol` column, the on-plot label already shows that column's value — but the plotly hover tooltip only displayed `ID:` and `geneSymbol:`, making the floating info box feel inconsistent with what's visible on the dot.
- `volcano_build_hover_text()` now accepts optional `lbl_vals` / `lbl_col_name` and appends a third hover line when both are supplied and length matches `ids`.
- `plotVolcano()` passes the resolved label values (post split/trim — matches the on-plot annotation) only when the chosen label column differs from both `id_col` and `geneSymbol_col` (case-insensitive), so no duplicate line appears for default selections.

## Files changed
- `R/tab_stat_plot_helpers.R` — extend `volcano_build_hover_text()` signature; gate the extra hover line in `plotVolcano()`.
- `tests/testthat/test-volcano-labeling.R` — three new `testthat` cases.

## Test plan
- [x] All 5 existing `volcano_build_hover_text` testthat cases still pass.
- [x] New: third line appears when `lbl_vals` + `lbl_col_name` provided and lengths match.
- [x] New: `lbl_vals` ignored when length mismatches `ids`.
- [x] New: label-only path (no `gs_vals`) renders `ID:` + label line.
- [x] Manual app check — open Comparison / Volcano tab:
  - [x] Default `id` selection: tooltip shows `ID:` + `geneSymbol:` only (unchanged).
  - [x] Pick the geneSymbol column itself as label: still just the two lines (no duplicate).
  - [x] Pick any other rdesc column (e.g. `accession_number`, `description`): tooltip adds `<column_name>: <value>` matching the on-plot label.
  - [x] Toggle split/trim on a multi-value label column: third hover line shows the resolved/displayed value, matching the dot's label.
- [x] PDF export still renders without error (`plotVolcano` is shared with the export path).