### PR TITLE
fix: QC > CV crash on non-GCT uploads without an 'id' column in the experimental design

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Protigy
 Title: Proteomics Toolset for Integrative Data Analysis
-Version: 2.6.0
+Version: 2.6.1
 Authors@R: c(
     person("Natalie M", "Clark", , "nclark@broadinstitute.org", role = c("aut", "cre")),
     person("Cameron", "Lian", , "glian@broadinstitute.org ", role = "aut"),

--- a/R/sidebar_setup_helpers_csv-excel-processing.R
+++ b/R/sidebar_setup_helpers_csv-excel-processing.R
@@ -512,8 +512,14 @@ createCdesc <- function(sample_ids, experimentalDesign, file_name) {
   # Get metadata columns (all columns except columnName)
   metadata_columns <- setdiff(names(experimentalDesign), "columnName")
   
-  # Create cdesc data.frame starting with Sample.ID
+  # Create cdesc data.frame. The `id` column is required by cmapR: subset_gct()
+  # -> subset_to_ids() looks up samples by a column literally named `id` (this is
+  # what parse_gctx() supplies for .gct uploads). Without it, any column-wise
+  # subset -- e.g. QC > CV's qc_cv_align_source() -- errors with
+  # "the following column names are not found in df: id". `Sample.ID` is retained
+  # as the user-facing annotation column that downstream tabs read.
   cdesc <- data.frame(
+    id        = sample_ids,
     Sample.ID = sample_ids,
     stringsAsFactors = FALSE
   )

--- a/tests/testthat/test-csv-excel-processing.R
+++ b/tests/testthat/test-csv-excel-processing.R
@@ -271,6 +271,55 @@ test_that("createCdesc creates correct column descriptions", {
   expect_equal(cdesc$Group, c("Group1", "Group2"))
 })
 
+test_that("createCdesc emits an 'id' column matching the sample ids (cmapR contract)", {
+  # cmapR's subset_gct() -> subset_to_ids() requires the cdesc to carry a column
+  # literally named 'id'. Experimental designs authored by users do NOT contain an
+  # 'id' column, so createCdesc must supply one itself (mirroring parse_gctx()).
+  experimental_design <- data.frame(
+    columnName = c("Sample1", "Sample2"),
+    Experiment = c("Control", "Treatment"),
+    Group      = c("Group1", "Group2"),
+    stringsAsFactors = FALSE
+  )
+  sample_columns <- c("Sample1", "Sample2")
+
+  cdesc <- createCdesc(sample_columns, experimental_design, "test_file.csv")
+
+  expect_true("id" %in% colnames(cdesc))
+  expect_equal(cdesc$id, sample_columns)
+})
+
+test_that("convertToGCT yields a cmapR-subsettable GCT when the experimental design has no 'id' column", {
+  # Regression: QC > CV called subset_gct() on a non-GCT upload whose experimental
+  # design lacked an 'id' column, tripping cmapR's "column names are not found in
+  # df: id" error. The constructed GCT must be subsettable by cid.
+  test_data <- data.frame(
+    protein_id = c("P1", "P2", "P3"),
+    Sample1    = c(1, 2, 3),
+    Sample2    = c(4, 5, 6),
+    stringsAsFactors = FALSE
+  )
+  experimental_design <- data.frame(
+    columnName = c("Sample1", "Sample2"),
+    Genotype   = c("WT", "MUT"),
+    Treatment  = c("A", "B"),
+    stringsAsFactors = FALSE
+  )
+
+  gct_obj <- convertToGCT(test_data, experimental_design, "test_file.csv", "protein_id")
+
+  expect_true("id" %in% colnames(gct_obj@cdesc))
+
+  # The failing operation from QC > CV (qc_cv_align_source / filtered_gct).
+  expect_no_error(
+    cmapR::subset_gct(
+      gct_obj,
+      rid = seq_len(nrow(gct_obj@mat)),
+      cid = seq_len(ncol(gct_obj@mat))
+    )
+  )
+})
+
 test_that("filterExperimentalColumns filters correctly", {
   experimental_design <- data.frame(
     columnName = c("Sample1", "Sample2"),


### PR DESCRIPTION
## Problem

Opening **QC > CV** crashes with:

```
the following column names are not found in df: id
```

when the dataset is uploaded as a **non-GCT file** (CSV/TSV/Excel) together with an experimental design that does **not** contain an `id` column — i.e. the normal case for a user-authored experimental design.

## Root cause

The error originates in **cmapR**, not Protigy. `cmapR::subset_gct()` unconditionally calls `subset_to_ids(cdesc, cid)` internally, which runs `check_colnames("id", df)` and requires the column descriptor (`cdesc`) to carry a column literally named `id`.

- `parse_gctx()` supplies that `id` column for real `.gct` uploads, so **GCT-file uploads work**.
- Protigy's `createCdesc()` (used for CSV/TSV/Excel uploads) built `cdesc` with `Sample.ID` but **no `id` column**, so the constructed GCT could not be column-subset by cmapR.

**Why it was never caught:** the bundled demo `inst/extdata/experimental_design.csv` happens to include an `id` annotation column, which `createCdesc()` copies verbatim into `cdesc`. That coincidental column satisfied cmapR in all existing tests/demos. Any user whose experimental design lacks an `id` column (the common case) hit the crash.

**Why only QC > CV:** `subset_gct()` is called in exactly two places in the codebase, both in the QC > CV module (`qc_cv_align_source()` on the default non-normalized render, and `filtered_gct()` on filter export). Other tabs use `mat()` / `@cdesc` / `melt_gct()`, which don't require an `id` column.

## Fix

`createCdesc()` now always emits an `id` cdesc column equal to the sample ids (retaining `Sample.ID` as the user-facing annotation), matching the `parse_gctx()` baseline. This is a construction-time invariant fix — no change to the CV module, and it makes every GCT built from a non-GCT upload conform to the cmapR contract.

## Testing (TDD)

- **RED:** Added two regression tests — one asserting `createCdesc` emits an `id` column, one reproducing the exact `subset_gct` failure via `convertToGCT` with an `id`-less experimental design. Both failed with the production error before the fix.
- **GREEN:** After the one-line-ish fix, both pass.
- **Full suite:** `devtools::test()` → **0 failed / 0 errors** (no `expect_named()` contract test regressed).
- **End-to-end with the real reporting files:** `convertToGCT()` → both QC > CV `subset_gct` call sites succeed, and a 33,751-feature CV table computes.

## Behavior note

The new `id` cdesc column now also appears in the QC > CV "Group by" selector, next to the pre-existing `Sample.ID`. This is **not new behavior** — parsed `.gct` uploads already exposed both `id` and `Sample.ID` there; the fix makes non-GCT uploads consistent with that established baseline. Hiding `id`/`Sample.ID` from group-by choices, if desired, is a separate optional UI change.

## Test plan

- [x] Upload a non-GCT file (CSV/TSV/Excel) with an experimental design that has **no** `id` column
- [x] Open **QC > CV** — verify it renders instead of erroring
- [x] Toggle the CV filter and export — verify the filtered GCT/CSV/PDF export succeeds
- [x] Confirm `.gct`-file uploads are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)