### PR TITLE
fix(volcano): decouple feature highlighting from labeling

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Protigy
 Title: Proteomics Toolset for Integrative Data Analysis
-Version: 2.6.1
+Version: 2.6.2
 Authors@R: c(
     person("Natalie M", "Clark", , "nclark@broadinstitute.org", role = c("aut", "cre")),
     person("Cameron", "Lian", , "glian@broadinstitute.org ", role = "aut"),

--- a/R/tab_stat_plot.R
+++ b/R/tab_stat_plot.R
@@ -663,14 +663,10 @@ statPlot_Ome_Server <- function(id,
       hidden_label_count(0L)
     })
 
-    # Auto-enable POI checkbox when proteins are added to the list
-    observeEvent(proteins_of_interest(), {
-      pois <- proteins_of_interest()
-      if (length(pois) > 0 && !"poi" %in% isolate(label_mode_for_contrast())) {
-        updateCheckboxGroupInput(session, "label_mode",
-          selected = unique(c(isolate(label_mode_for_contrast()), "poi")))
-      }
-    }, ignoreNULL = FALSE)
+    # NOTE: Searching / clicking a feature adds it to the POI list, which
+    # highlights it in magenta via the highlight pass in add_volcano_labels().
+    # It does NOT auto-check "Feature(s) of interest" in Label Features  -  search
+    # controls highlighting; the checkbox independently controls labeling.
 
     # Hidden label overlap note
     output$hidden_labels_warning <- renderUI({

--- a/R/tab_stat_plot_helpers.R
+++ b/R/tab_stat_plot_helpers.R
@@ -232,7 +232,33 @@ plotVolcano <- function(ome, volcano_groups, volcano_contrasts, df, stat_params,
       annotate("text", x = x_range[2], y = y_range[2], label = group1, hjust = 1.1, vjust = 3.1, size = 5, fontface = "bold", color = "red")
   }
   
-  # Add ggrepel labels for PDF export (mirrors add_volcano_labels color logic)
+  # Highlight and label are independent, mirroring add_volcano_labels():
+  #   * HIGHLIGHT (magenta geom_point)  -  POI-exclusive; drawn whenever
+  #     label_proteins are supplied, regardless of label_mode.
+  #   * LABEL (ggrepel text)             -  driven only by label_mode.
+
+  ## HIGHLIGHT PASS  -  magenta markers for POI points, independent of label_mode.
+  if (length(label_proteins) > 0) {
+    poi_hl <- df[df$id %in% label_proteins, , drop = FALSE]
+    if (nrow(poi_hl) > 0) {
+      poi_hl$label_col <- .volcano_label_hex
+      volcano <- volcano +
+        geom_point(
+          data        = poi_hl,
+          aes(
+            x     = .data$logFC,
+            y     = .data$logP,
+            color = .data$label_col,
+            text  = .data$.hover_text
+          ),
+          inherit.aes = FALSE,
+          size        = 2,
+          show.legend = FALSE
+        )
+    }
+  }
+
+  ## LABEL PASS  -  ggrepel text annotations, driven by label_mode only.
   if (length(label_mode) > 0) {
     label_df_gg <- data.frame(
       id = character(0), logFC = numeric(0), logP = numeric(0),
@@ -273,18 +299,6 @@ plotVolcano <- function(ome, volcano_groups, volcano_contrasts, df, stat_params,
       )
       label_df_gg$.hover_text <- df$.hover_text[match(as.character(label_df_gg$id), as.character(df$id))]
       volcano <- volcano +
-        geom_point(
-          data        = label_df_gg,
-          aes(
-            x     = .data$logFC,
-            y     = .data$logP,
-            color = .data$label_col,
-            text  = .data$.hover_text
-          ),
-          inherit.aes = FALSE,
-          size        = 2,
-          show.legend = FALSE
-        ) +
         ggrepel::geom_text_repel(
           data          = label_df_gg,
           aes(x = .data$logFC, y = .data$logP, label = .data$label_txt,
@@ -610,11 +624,20 @@ volcano_label_union_for_ome <- function(stat_results_ome, stat_params_ome, label
 }
 
 
-# Add color-coded feature labels as Plotly annotations.
+# Add the volcano highlight overlay and color-coded feature labels.
+#
+# Highlighting (magenta point overlay) and labeling (text annotations) are two
+# INDEPENDENT concerns:
+#   * Highlight  -  driven ONLY by `poi` (search / click selections). POI points
+#     always get the magenta marker overlay, regardless of `label_mode`. This is
+#     POI-exclusive: significant / top-N points are NOT highlighted magenta.
+#   * Label      -  driven ONLY by `label_mode`. Text annotations are drawn for
+#     whichever modes are active ("poi", "significant", "significant_top20").
 #
 # p               - plotly object (output of ggplotly)
 # df              - data frame with columns: id, logFC, logP, Significant, geneSymbol
-# poi             - character vector of feature IDs to label as POI
+# poi             - character vector of feature IDs to highlight (and label when
+#                   "poi" is in label_mode)
 # label_mode      - character vector; "poi", "significant_top20", and/or "significant"
 #                 ("significant" includes all sig; if both sig modes are set, all wins)
 # y_cutoff        - significance y threshold (used to identify Significant points)
@@ -625,16 +648,41 @@ add_volcano_labels <- function(p, df, poi, label_mode, y_cutoff,
                                 label_display_trim_enabled = FALSE,
                                 n_top = 20L) {
 
+  poi <- unique(as.character(poi))
+
   show_poi <- "poi" %in% label_mode
   show_sig <- "significant" %in% label_mode
   show_sig_top <- "significant_top20" %in% label_mode
 
+  ## HIGHLIGHT PASS  ----------------------------------------------------------
+  # Draw the magenta marker overlay for every POI point, independent of any
+  # label mode. This is what "search to highlight" produces on its own.
+  poi_rows_all <- df[as.character(df$id) %in% poi, , drop = FALSE]
+  if (nrow(poi_rows_all) > 0) {
+    p <- plotly::add_trace(
+      p,
+      data       = poi_rows_all,
+      x          = ~logFC,
+      y          = ~logP,
+      type       = "scatter",
+      mode       = "markers",
+      marker     = list(color = .volcano_label_hex, size = 9,
+                        line = list(color = "white", width = 1.5)),
+      showlegend = FALSE,
+      hoverinfo  = "skip",
+      inherit    = FALSE
+    )
+  }
+
+  # Nothing to label if no label mode is active: highlight (above) may still have
+  # been applied, but no text annotations are drawn.
   if (!show_poi && !show_sig && !show_sig_top) {
     hidden_count_rv(0L)
     return(p)
   }
 
-  # Build label data frame
+  ## LABEL PASS  --------------------------------------------------------------
+  # Build the set of features that receive text annotations, driven by label_mode.
   label_df <- data.frame(
     id        = character(0),
     logFC     = numeric(0),
@@ -732,20 +780,9 @@ add_volcano_labels <- function(p, df, poi, label_mode, y_cutoff,
   label_df_kept <- label_df[keep_idx, , drop = FALSE]
   if (nrow(label_df_kept) == 0) return(p)
 
-  # Colored marker overlay for labeled points
-  p <- plotly::add_trace(
-    p,
-    data       = label_df_kept,
-    x          = ~logFC,
-    y          = ~logP,
-    type       = "scatter",
-    mode       = "markers",
-    marker     = list(color = label_df_kept$label_col, size = 9,
-                      line = list(color = "white", width = 1.5)),
-    showlegend = FALSE,
-    hoverinfo  = "skip",
-    inherit    = FALSE
-  )
+  # No marker overlay here: the magenta point highlight is POI-exclusive and is
+  # drawn in the highlight pass above. The label pass adds text annotations only,
+  # so significant / top-N labeled points keep their normal significance color.
 
   # White-background text annotations (no arrow)
   annotations <- lapply(seq_len(nrow(label_df_kept)), function(i) {

--- a/tests/testthat/test-volcano-labeling.R
+++ b/tests/testthat/test-volcano-labeling.R
@@ -436,6 +436,156 @@ test_that("add_volcano_labels with significant_top20 caps labeled significant ro
   expect_equal(n_ann, 20L)
 })
 
+## Highlight vs. label separation #############################################
+# Search-to-highlight (POI) controls the magenta point overlay; "Label Features"
+# (label_mode) controls only whether text annotations are drawn. Highlighting a
+# POI must NOT require a label mode, and significant/top-N modes color no points
+# magenta (highlight is POI-exclusive).
+
+# Count magenta highlight overlay traces (the "#FF00FF" marker layer) in a built
+# plotly object. The base scatter uses plotly's default blue, so any trace whose
+# marker color is the volcano label hex is a highlight overlay.
+count_magenta_traces <- function(built) {
+  sum(vapply(built$x$data, function(tr) {
+    isTRUE(any(unlist(tr$marker$color) == .volcano_label_hex))
+  }, logical(1)))
+}
+
+test_that("add_volcano_labels highlights POI in magenta with no label mode and no annotations", {
+  skip_if_not_installed("plotly")
+  df <- data.frame(
+    id = c("A", "B", "C"), logFC = c(1, -1, 0.1),
+    logP = c(4, 3, 1), Significant = c(TRUE, TRUE, FALSE),
+    geneSymbol = c("G1", "G2", "G3"), stringsAsFactors = FALSE
+  )
+  p  <- make_test_plotly(df)
+  rv <- mock_rv()
+  result <- add_volcano_labels(p, df, poi = "A", label_mode = character(0),
+                               y_cutoff = 2, hidden_count_rv = rv)
+  built <- plotly::plotly_build(result)
+  # One magenta highlight overlay for the single POI point ...
+  expect_equal(count_magenta_traces(built), 1L)
+  # ... and NO text annotations, because no label mode is active.
+  expect_length(built$x$layout$annotations %||% list(), 0L)
+})
+
+test_that("add_volcano_labels with empty poi and no mode adds no highlight and no annotations", {
+  skip_if_not_installed("plotly")
+  df <- data.frame(
+    id = c("A", "B"), logFC = c(1, -1), logP = c(4, 3),
+    Significant = c(TRUE, FALSE), geneSymbol = c("G1", "G2"),
+    stringsAsFactors = FALSE
+  )
+  p  <- make_test_plotly(df)
+  rv <- mock_rv()
+  result <- add_volcano_labels(p, df, poi = character(0), label_mode = character(0),
+                               y_cutoff = 2, hidden_count_rv = rv)
+  built <- plotly::plotly_build(result)
+  expect_equal(count_magenta_traces(built), 0L)
+  expect_length(built$x$layout$annotations %||% list(), 0L)
+})
+
+test_that("add_volcano_labels adds POI text annotation only when 'poi' label mode is on", {
+  skip_if_not_installed("plotly")
+  df <- data.frame(
+    id = c("A", "B", "C"), logFC = c(1, -1, 0.1),
+    logP = c(4, 3, 1), Significant = c(TRUE, TRUE, FALSE),
+    geneSymbol = c("G1", "G2", "G3"), stringsAsFactors = FALSE
+  )
+  p  <- make_test_plotly(df)
+  rv <- mock_rv()
+  result <- add_volcano_labels(p, df, poi = "A", label_mode = "poi",
+                               y_cutoff = 2, hidden_count_rv = rv)
+  built <- plotly::plotly_build(result)
+  # Still highlighted, and now also labeled.
+  expect_equal(count_magenta_traces(built), 1L)
+  ann <- built$x$layout$annotations %||% list()
+  expect_length(ann, 1L)
+  expect_equal(ann[[1]]$text, "G1")
+})
+
+test_that("add_volcano_labels significant mode labels points but adds no magenta highlight (POI-exclusive)", {
+  skip_if_not_installed("plotly")
+  df <- data.frame(
+    id = c("A", "B", "C"), logFC = c(1, -1, 0.1),
+    logP = c(4, 3, 1), Significant = c(TRUE, TRUE, FALSE),
+    geneSymbol = c("G1", "G2", "G3"), stringsAsFactors = FALSE
+  )
+  p  <- make_test_plotly(df)
+  rv <- mock_rv()
+  result <- add_volcano_labels(p, df, poi = character(0), label_mode = "significant",
+                               y_cutoff = 2, hidden_count_rv = rv)
+  built <- plotly::plotly_build(result)
+  # Two significant points get text labels ...
+  expect_length(built$x$layout$annotations %||% list(), 2L)
+  # ... but significance alone does NOT paint points magenta.
+  expect_equal(count_magenta_traces(built), 0L)
+})
+
+## plotVolcano highlight/label parity (PDF export path) #######################
+# The exported ggplot must mirror the on-screen separation: POI points get the
+# magenta highlight geom even with no label mode; significant/top-N points are
+# labeled but not highlighted magenta (POI-exclusive highlight).
+
+# Minimal two-sample stat_results df + reactive-style accessors for plotVolcano.
+make_volcano_export_fixture <- function() {
+  df <- data.frame(
+    id         = c("A", "B", "C", "D"),
+    geneSymbol = c("GA", "GB", "GC", "GD"),
+    check.names = FALSE, stringsAsFactors = FALSE
+  )
+  df[["logFC.X_over_Y"]]        <- c(2, -2, 0.1, 1.5)
+  df[["Log.P.Value.X_over_Y"]]  <- c(5, 4, 0.5, 3)
+  df[["adj.P.Val.X_over_Y"]]    <- c(0.001, 0.002, 0.9, 0.01)
+  df[["P.value.X_over_Y"]]      <- c(0.0001, 0.0002, 0.5, 0.001)
+  sp <- list(myome = list(test = "Two-sample Moderated T-test", cutoff = 0.05,
+                          stat = "p.val", contrasts = "X / Y", groups = NULL))
+  list(df = df, statp = function() sp, statr = function() list(myome = df))
+}
+
+# Count magenta highlight POINT layers: geom_point layers whose data carries the
+# magenta highlight color. Excludes ggrepel text layers (their text may be magenta
+# for labeling, which is a separate concern from point highlighting).
+count_magenta_geom_layers <- function(gg) {
+  sum(vapply(gg$layers, function(ly) {
+    d <- ly$data
+    inherits(ly$geom, "GeomPoint") &&
+      is.data.frame(d) && "label_col" %in% names(d) && nrow(d) > 0 &&
+      any(d$label_col == .volcano_label_hex)
+  }, logical(1)))
+}
+
+test_that("plotVolcano highlights POI in magenta even when label_mode is empty", {
+  skip_if_not_installed("ggplot2")
+  fx <- make_volcano_export_fixture()
+  gg <- plotVolcano("myome", NULL, "X / Y", fx$df, fx$statp, fx$statr,
+                    label_proteins = c("A"), label_mode = character(0))
+  expect_gte(count_magenta_geom_layers(gg), 1L)
+})
+
+test_that("plotVolcano does not highlight anything magenta when no POI and no label mode", {
+  skip_if_not_installed("ggplot2")
+  fx <- make_volcano_export_fixture()
+  gg <- plotVolcano("myome", NULL, "X / Y", fx$df, fx$statp, fx$statr,
+                    label_proteins = character(0), label_mode = character(0))
+  expect_equal(count_magenta_geom_layers(gg), 0L)
+})
+
+test_that("plotVolcano significant mode does not add a magenta highlight geom (POI-exclusive)", {
+  skip_if_not_installed("ggplot2")
+  skip_if_not_installed("ggrepel")
+  fx <- make_volcano_export_fixture()
+  gg <- plotVolcano("myome", NULL, "X / Y", fx$df, fx$statp, fx$statr,
+                    label_proteins = character(0), label_mode = "significant")
+  # No POI -> no magenta highlight geom, even though significant points are labeled.
+  expect_equal(count_magenta_geom_layers(gg), 0L)
+  # A ggrepel text layer should still be present for the labeled significant points.
+  has_repel <- any(vapply(gg$layers, function(ly) {
+    inherits(ly$geom, "GeomTextRepel")
+  }, logical(1)))
+  expect_true(has_repel)
+})
+
 ## regex_escape ###############################################################
 
 test_that("regex_escape escapes PCRE metacharacters", {


### PR DESCRIPTION
## Issue

In **Statistics › Volcano Plot**, search-to-highlight and the **Label Features** customization were coupled. When a user searched features to highlight *and* had **Feature(s) of interest** checked, the matched points were highlighted in magenta **with labels**. The moment the user unchecked **Feature(s) of interest**, **both the points and the labels disappeared** from the plot.

The two controls should be independent: search-to-highlight should control *which points are colored magenta*, while **Label Features** should control *whether text labels are drawn*.

## Root cause

There was **no separate highlight mechanism**. The magenta a user reads as "highlighted" was the colored-marker overlay built *inside* `add_volcano_labels()` — the same function, from the same `label_df`, that draws the text annotations. Both were gated by a single early return (`R/tab_stat_plot_helpers.R`):

```r
if (!show_poi && !show_sig && !show_sig_top) {
  hidden_count_rv(0L)
  return(p)          # leaves BEFORE any magenta marker is drawn
}
```

Uncheck `Feature(s) of interest` → `show_poi` is `FALSE` → the function returns early → both the magenta markers **and** the labels vanish. The base plot (`plotVolcano`) only ever colors points by significance (`darkred`/`gray`), never by POI, so there was nothing for the highlight to fall back to.

A second observer (`R/tab_stat_plot.R`) reinforced the coupling by auto-checking the `poi` label box whenever a feature was added, making a search action silently turn on labeling.

## Behavior before

| After searching feature A… | Magenta highlight | Text label |
|---|---|---|
| box **checked** | shown | shown |
| box **unchecked** | **gone** | gone |

Searching always forced labels on; unchecking the label box also removed the highlight.

## Behavior after

Highlighting (POI membership) and labeling (label mode) are now fully independent:

| State | Magenta highlight | Text label |
|---|---|---|
| No search, no label | — | — |
| Searched A, box **unchecked** | **shown** | — |
| Searched A, box **checked** (`poi`) | shown | shown |
| `All significant` (no search) | — | shown (POI-exclusive: no magenta) |
| Searched A + `All significant` | shown (A only) | shown (sig + A) |

Search → magenta highlight, no label. Then check **Feature(s) of interest** → labels are added on top. The magenta highlight is **POI-exclusive**: `Top significant` / `All significant` label their points but do not paint them magenta.

## Changes

**`R/tab_stat_plot_helpers.R`**
- `add_volcano_labels()` (interactive plotly) split into a **highlight pass** (magenta marker overlay for POI points, drawn regardless of `label_mode`) and a **label pass** (text annotations, gated by `label_mode`). The old shared early return now fires only when there is nothing to highlight *and* nothing to label. The label pass no longer draws point markers, so significant/top-N points get text only.
- `plotVolcano()` (PDF export) given the same two-pass split for on-screen/export parity: a POI-only magenta `geom_point`, and a `label_mode`-gated `ggrepel` text layer.

**`R/tab_stat_plot.R`**
- Removed the observer that auto-checked `"poi"` on every search/click — the behavior that fused the two controls. Search now controls highlighting only; the checkbox independently controls labels.

**`tests/testthat/test-volcano-labeling.R`**
- 7 new tests (4 for `add_volcano_labels`, 3 for `plotVolcano`) asserting highlight-vs-label independence and POI-exclusive highlighting. Written test-first (RED → GREEN).

## Test plan

- [x] `devtools::test()` — full suite: **0 failed, 0 errors** (new warning count is a pre-existing benign `Ignoring unknown aesthetics: text` surfaced only by the new pure-ggplot test; the app path consumes it via `ggplotly()`).
- [x] New unit tests cover: POI highlight with empty label mode + zero annotations; empty POI + empty mode → nothing added; POI label only when `poi` mode is on; significant mode labels points without a magenta highlight; PDF-export (`plotVolcano`) parity for all three.
- [x] Manual browser verification in the running app: search a feature → magenta with no label; check **Feature(s) of interest** → label appears; toggle `Top/All significant` → labels appear without magenta on non-POI points; export PDF/CSV and confirm parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
