### PR TITLE
fix(lm): prevent crash when unchecking a model variable

### DIFF
--- a/R/tab_lm_setup.R
+++ b/R/tab_lm_setup.R
@@ -379,15 +379,10 @@ lmSetup_Tab_Server <- function(id = "lmSetupTab", GCTs_and_params, globals, pare
 
       include_intercept <- isTRUE(input$include_intercept)
 
-      # Parse interaction terms
-      interactions <- list()
-      if (!is.null(input$interaction_terms)) {
-        vars_list <- input$selected_variables
-        pairs <- combn(vars_list, 2, simplify = FALSE)
-        pair_labels <- sapply(pairs, function(p) paste(p[1], ":", p[2]))
-        selected_indices <- which(pair_labels %in% input$interaction_terms)
-        interactions <- pairs[selected_indices]
-      }
+      # Parse interaction terms. parse_interaction_terms() is crash-proof when
+      # the selection shrinks to a single variable while a stale (non-NULL)
+      # interaction_terms value persists -- it never calls combn() with < 2 vars.
+      interactions <- parse_interaction_terms(vars, input$interaction_terms)
 
       build_formula_string(vars, include_intercept, interactions)
     })
@@ -831,6 +826,29 @@ lmSetup_Tab_Server <- function(id = "lmSetupTab", GCTs_and_params, globals, pare
         )))
       }
     })
+
+    # Fresh start when the set of model variables changes. Contrast rows store
+    # design-coefficient names (e.g. "SubgroupB"); changing which variables are
+    # selected invalidates those coefficients, so stale num/den references would
+    # point at columns that no longer exist. Reseed to a single empty row and
+    # clear the (now stale) interaction selection, matching the "Clear all"
+    # state, so the user rebuilds contrasts against the new design. ignoreInit
+    # avoids wiping anything on module startup / first selection.
+    observeEvent(input$selected_variables, {
+      contrast_rows(list(list(
+        id = new_contrast_row_id(),
+        type = "simple",
+        num = "",
+        den = "",
+        advanced_expr = "",
+        label = "",
+        label_user_edited = FALSE
+      )))
+      # Drop the stale interaction picker selection so formula_string() and the
+      # fit never see an interaction referencing a removed variable.
+      shinyWidgets::updatePickerInput(session, "interaction_terms",
+                                      selected = character(0))
+    }, ignoreInit = TRUE, ignoreNULL = FALSE)
 
     # Helper to stably derive the display id (C1, C2, ...) from position
     display_ids <- function(rows) {
@@ -1326,17 +1344,11 @@ lmSetup_Tab_Server <- function(id = "lmSetupTab", GCTs_and_params, globals, pare
       vtypes <- variable_types()
       gcts <- GCTs()
 
-      # Parse interactions
-      interactions <- list()
-      if (!is.null(input$interaction_terms) && !is.null(input$selected_variables)) {
-        vars_list <- input$selected_variables
-        if (length(vars_list) >= 2) {
-          pairs <- combn(vars_list, 2, simplify = FALSE)
-          pair_labels <- sapply(pairs, function(p) paste(p[1], ":", p[2]))
-          selected_indices <- which(pair_labels %in% input$interaction_terms)
-          interactions <- pairs[selected_indices]
-        }
-      }
+      # Parse interactions (shares the crash-proof helper with formula_string()
+      # so the fit's interaction set can never diverge from the previewed one).
+      interactions <- parse_interaction_terms(
+        input$selected_variables, input$interaction_terms
+      )
 
       # Build contrasts list from structured state (empty rows ignored).
       # Use the user-facing, whitespace-stripped `label` as the column key so

--- a/R/tab_lm_setup_helpers.R
+++ b/R/tab_lm_setup_helpers.R
@@ -239,6 +239,36 @@ summarize_sample_drops <- function(cdesc, model_vars) {
 }
 
 
+#' Resolve selected interaction terms into variable pairs
+#'
+#' Turns the LM setup module's `(selected_variables, interaction_terms)` input
+#' pair into the list of interaction variable pairs consumed by
+#' [build_formula_string()] and the fit. Crucially, it is crash-proof for any
+#' number of selected variables: the interaction picker's `interaction_terms`
+#' checkbox input persists stale (non-`NULL`) after a variable is unchecked, so
+#' this helper must NOT call `utils::combn(selected_variables, 2)` unless at
+#' least two variables are currently selected -- `combn(x, 2)` errors with
+#' "n < m" when `length(x) < 2`. Any stale interaction label that no longer maps
+#' to a current pair is silently dropped.
+#'
+#' @param selected_variables Character vector of currently selected variable
+#'   names (`input$selected_variables`).
+#' @param interaction_terms Character vector of checked interaction labels in the
+#'   picker's `"A : B"` format (`input$interaction_terms`); may be `NULL`.
+#' @return A list of length-2 character vectors (the chosen interaction pairs),
+#'   in `combn()` enumeration order. Empty list when fewer than two variables
+#'   are selected, when `interaction_terms` is empty, or when no label matches.
+parse_interaction_terms <- function(selected_variables, interaction_terms) {
+  # Fewer than two variables -> no pairs are possible; never touch combn().
+  if (length(selected_variables) < 2) return(list())
+  if (length(interaction_terms) == 0) return(list())
+
+  pairs <- utils::combn(selected_variables, 2, simplify = FALSE)
+  pair_labels <- vapply(pairs, function(p) paste(p[1], ":", p[2]), character(1))
+  pairs[pair_labels %in% interaction_terms]
+}
+
+
 #' Build a formula string from user selections
 #'
 #' @param variables Character vector of selected variable names

--- a/tests/testthat/test-lm-parse-interaction-terms.R
+++ b/tests/testthat/test-lm-parse-interaction-terms.R
@@ -1,0 +1,98 @@
+################################################################################
+# Tests for parse_interaction_terms() - the pure helper that turns the LM
+# setup module's (selected_variables, interaction_terms) input pair into the
+# list of interaction variable pairs consumed by build_formula_string() and the
+# fit.
+#
+# Regression driver: unchecking one of two selected variables used to crash the
+# app. The `interaction_terms` checkbox input persists STALE (non-NULL) after a
+# variable is removed, and formula_string() called combn(selected_variables, 2)
+# unconditionally whenever interaction_terms was non-NULL. combn(x, 2) errors
+# with "n < m" when length(x) < 2, so the length-1 selection blew up the whole
+# design/preview reactive chain. This helper must be crash-proof for any
+# selected-variable length, including 0 and 1.
+#
+# Contract:
+#   parse_interaction_terms(selected_variables, interaction_terms) -> list of
+#   length-2 character vectors (the chosen interaction pairs), in the same order
+#   combn() enumerates them. Returns an empty list when:
+#     - fewer than 2 variables are selected (NOTHING to interact), OR
+#     - interaction_terms is NULL / empty, OR
+#     - no interaction_terms label matches a current pair (all stale).
+#   The pair labels are matched against interaction_terms using the exact
+#   "A : B" format the interaction picker renders (space-colon-space).
+################################################################################
+
+library(testthat)
+
+
+test_that("returns empty list and does NOT call combn when a single variable is selected", {
+  # This is the crash repro: 2 vars were selected (so interaction_terms is a
+  # stale non-NULL label like "Subgroup : Experiment"), then one var is
+  # unchecked leaving length 1. Must return list(), never error.
+  expect_silent(
+    res <- parse_interaction_terms(
+      selected_variables = "Subgroup",
+      interaction_terms  = "Subgroup : Experiment"
+    )
+  )
+  expect_identical(res, list())
+})
+
+
+test_that("returns empty list for zero selected variables", {
+  expect_identical(
+    parse_interaction_terms(character(0), "Subgroup : Experiment"),
+    list()
+  )
+  expect_identical(
+    parse_interaction_terms(NULL, "Subgroup : Experiment"),
+    list()
+  )
+})
+
+
+test_that("returns empty list when interaction_terms is NULL or empty", {
+  expect_identical(
+    parse_interaction_terms(c("A", "B"), NULL),
+    list()
+  )
+  expect_identical(
+    parse_interaction_terms(c("A", "B"), character(0)),
+    list()
+  )
+})
+
+
+test_that("returns the selected interaction pair for two variables", {
+  res <- parse_interaction_terms(
+    selected_variables = c("Subgroup", "Experiment"),
+    interaction_terms  = "Subgroup : Experiment"
+  )
+  expect_length(res, 1L)
+  expect_identical(res[[1]], c("Subgroup", "Experiment"))
+})
+
+
+test_that("returns only the interaction pairs the user actually checked", {
+  # 3 vars -> combn gives 3 candidate pairs; user checked only 2 of them.
+  res <- parse_interaction_terms(
+    selected_variables = c("A", "B", "C"),
+    interaction_terms  = c("A : B", "B : C")
+  )
+  expect_length(res, 2L)
+  expect_identical(res[[1]], c("A", "B"))
+  expect_identical(res[[2]], c("B", "C"))
+})
+
+
+test_that("drops stale interaction labels that no longer correspond to a pair", {
+  # interaction_terms still references a removed variable "C"; only the A:B
+  # pair is still valid. The stale "A : C" must be silently ignored.
+  res <- parse_interaction_terms(
+    selected_variables = c("A", "B"),
+    interaction_terms  = c("A : B", "A : C")
+  )
+  expect_length(res, 1L)
+  expect_identical(res[[1]], c("A", "B"))
+})

--- a/tests/testthat/test-lm-reset-on-variable-change.R
+++ b/tests/testthat/test-lm-reset-on-variable-change.R
@@ -1,0 +1,99 @@
+################################################################################
+# Tests for the "fresh start on variable change" reset in the LM setup module.
+#
+# Bug: after configuring a 2-variable model (reference levels, contrasts), the
+# user unchecks one variable. The stale contrast rows reference design
+# coefficients that no longer exist, and the stale interaction_terms selection
+# used to crash formula_string(). Expected behavior (user-stated): changing the
+# set of selected variables clears the contrast configuration for a fresh start
+# against the new variable list.
+#
+# These tests drive lmSetup_Tab_Server via shiny::testServer and assert that
+# mutating input$selected_variables reseeds contrast_rows to a single empty row
+# and does not error.
+################################################################################
+
+library(testthat)
+
+# Minimal GCTs_and_params fixture backed by the packaged brca proteome GCT so
+# cdesc()/GCTs() resolve inside the setup server.
+make_lm_setup_gcap <- function() {
+  e <- new.env()
+  utils::data("brca_retrospective_v5.0_proteome_gct", package = "Protigy",
+              envir = e)
+  g <- e[["brca_retrospective_v5.0_proteome_gct"]]
+  shiny::reactiveVal(list(
+    GCTs = list(proteome = g),
+    parameters = list(proteome = list(annotation_column = "geneSymbol"))
+  ))
+}
+
+make_globals <- function() {
+  shiny::reactiveValues(default_ome = "proteome", colors = list())
+}
+
+# A non-empty contrast-row list standing in for user-configured contrasts.
+# Uses PAM50 coefficient names (real factor levels in the brca proteome cdesc).
+configured_rows <- function() {
+  list(list(id = "row_1", type = "simple",
+            num = "PAM50LumA", den = "PAM50Basal",
+            advanced_expr = "", label = "LumA-Basal", label_user_edited = FALSE),
+       list(id = "row_2", type = "simple",
+            num = "PAM50LumB", den = "PAM50Basal",
+            advanced_expr = "", label = "LumB-Basal", label_user_edited = FALSE))
+}
+
+
+test_that("changing selected_variables reseeds contrast_rows to a single empty row", {
+  shiny::testServer(
+    lmSetup_Tab_Server,
+    args = list(
+      id = "lm",
+      GCTs_and_params = make_lm_setup_gcap(),
+      globals = make_globals()
+    ),
+    {
+      session$setInputs(selected_ome = "proteome")
+      # User has configured two contrasts against a 2-variable model.
+      session$setInputs(selected_variables = c("PAM50", "ER.Status"))
+      contrast_rows(configured_rows())
+      expect_length(contrast_rows(), 2L)
+
+      # User unchecks one variable -> fresh start.
+      session$setInputs(selected_variables = "PAM50")
+
+      rows <- contrast_rows()
+      expect_length(rows, 1L)
+      expect_identical(rows[[1]]$type, "simple")
+      expect_identical(rows[[1]]$num, "")
+      expect_identical(rows[[1]]$den, "")
+    }
+  )
+})
+
+
+test_that("unchecking a variable after an interaction was chosen does not error", {
+  # The original crash: interaction_terms persists stale (non-NULL) after a
+  # variable is removed, and formula_string()'s combn() blew up on length 1.
+  shiny::testServer(
+    lmSetup_Tab_Server,
+    args = list(
+      id = "lm",
+      GCTs_and_params = make_lm_setup_gcap(),
+      globals = make_globals()
+    ),
+    {
+      session$setInputs(selected_ome = "proteome")
+      session$setInputs(selected_variables = c("PAM50", "ER.Status"))
+      session$setInputs(interaction_terms = "PAM50 : ER.Status")
+
+      # Drop to one variable; interaction_terms is still non-NULL (stale).
+      expect_error(
+        session$setInputs(selected_variables = "PAM50"),
+        NA  # NA => assert NO error is thrown
+      )
+      # formula_string must still resolve to a valid single-variable formula.
+      expect_match(formula_string(), "PAM50")
+    }
+  )
+})


### PR DESCRIPTION
## Problem

Configuring a 2-variable linear model (reference levels, contrasts, and an **interaction term**), then **unchecking one of the two variables**, crashed the app.

## Root cause

`formula_string()` (in `tab_lm_setup.R`) ran `combn(input$selected_variables, 2)` unconditionally whenever `input$interaction_terms` was non-`NULL`. Shiny does **not** clear that interaction-picker input when a variable is removed, so it persists stale. On a 2→1 shrink, `combn(single_var, 2)` throws `n < m`, and since `formula_string()` has no `tryCatch`, the error propagated through the entire design/preview reactive chain → crash.

Verified: `combn(c("A"), 2)` → `Error: n < m`; `combn(c("A","B"), 2)` → ok.

## Fix

**Root cause (defense-in-depth):**
- New pure helper `parse_interaction_terms(selected_variables, interaction_terms)` returns an empty list — **never calling `combn`** — when fewer than two variables are selected, and drops stale interaction labels that no longer map to a current pair.
- Wired into both `formula_string()` (the crash site) **and** the run handler, unifying two previously-divergent `combn` blocks so the previewed and fitted interaction sets can never disagree.

**Expected behavior (user-requested "fresh start"):**
- Added the missing `observeEvent(input$selected_variables, …)` that reseeds contrast rows to a single empty row and clears the stale interaction selection whenever the variable set changes. Contrast num/den store design-coefficient names that *any* variable change can orphan, so a reset is the correct fresh-start semantics. `ignoreInit = TRUE` avoids wiping state on module startup.

## Testing (TDD, RED→GREEN)

- **`test-lm-parse-interaction-terms.R`** (13 assertions): helper is crash-proof for 0/1/2/3 selected variables; matches the picker's `"A : B"` label format; drops stale labels.
- **`test-lm-reset-on-variable-change.R`** (7 assertions, `testServer`): changing `selected_variables` reseeds contrasts to one empty row; unchecking after an interaction was chosen no longer errors and `formula_string()` resolves to the single-variable formula.
- Full **LM suite: 430 passed / 0 failed / 0 errors**; ASCII-source guard green; `NAMESPACE` unchanged (helper is internal, unexported like its sibling `build_formula_string`).

## Manual verification (needs a live app session)

In the running app: pick 2 variables, add an interaction, configure a contrast, then uncheck one variable — confirm no crash, the formula updates to the single variable, and the contrast card resets to an empty row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)